### PR TITLE
Reduce EMA RAM usage and training overhead with local-shard EMA

### DIFF
--- a/long_video/trainer/diffusion.py
+++ b/long_video/trainer/diffusion.py
@@ -145,7 +145,7 @@ class Trainer:
         if self.config.ema_start_step < self.step:
             state_dict = {
                 "generator": generator_state_dict,
-                "generator_ema": self.generator_ema.state_dict(),
+                "generator_ema": self.generator_ema.full_state_dict(self.model.generator),
             }
         else:
             state_dict = {

--- a/long_video/trainer/distillation.py
+++ b/long_video/trainer/distillation.py
@@ -184,7 +184,7 @@ class Trainer:
             state_dict = {
                 "generator": generator_state_dict,
                 "critic": critic_state_dict,
-                "generator_ema": self.generator_ema.state_dict(),
+                "generator_ema": self.generator_ema.full_state_dict(self.model.generator),
             }
         else:
             state_dict = {

--- a/long_video/trainer/gan.py
+++ b/long_video/trainer/gan.py
@@ -216,7 +216,7 @@ class Trainer:
             state_dict = {
                 "generator": generator_state_dict,
                 "critic": critic_state_dict,
-                "generator_ema": self.generator_ema.state_dict(),
+                "generator_ema": self.generator_ema.full_state_dict(self.model.generator),
             }
         else:
             state_dict = {

--- a/long_video/utils/distributed.py
+++ b/long_video/utils/distributed.py
@@ -96,18 +96,14 @@ class EMA_FSDP:
 
     @torch.no_grad()
     def _init_shadow(self, fsdp_module):
-        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-        with FSDP.summon_full_params(fsdp_module, writeback=False):
-            for n, p in fsdp_module.module.named_parameters():
-                self.shadow[n] = p.detach().clone().float().cpu()
+        for n, p in fsdp_module.module.named_parameters():
+            self.shadow[n] = p.detach().clone().float().cpu()
 
     @torch.no_grad()
     def update(self, fsdp_module):
         d = self.decay
-        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-        with FSDP.summon_full_params(fsdp_module, writeback=False):
-            for n, p in fsdp_module.module.named_parameters():
-                self.shadow[n].mul_(d).add_(p.detach().float().cpu(), alpha=1. - d)
+        for n, p in fsdp_module.module.named_parameters():
+            self.shadow[n].mul_(d).add_(p.detach().float().cpu(), alpha=1. - d)
 
     # Optional helpers ---------------------------------------------------
     def state_dict(self):
@@ -117,9 +113,29 @@ class EMA_FSDP:
         self.shadow = {k: v.clone() for k, v in sd.items()}
 
     def copy_to(self, fsdp_module):
-        # load EMA weights into an (unwrapped) copy of the generator
-        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-        with FSDP.summon_full_params(fsdp_module, writeback=True):
-            for n, p in fsdp_module.module.named_parameters():
-                if n in self.shadow:
-                    p.data.copy_(self.shadow[n].to(p.dtype, device=p.device))
+        for n, p in fsdp_module.module.named_parameters():
+            if n in self.shadow:
+                p.data.copy_(self.shadow[n].to(dtype=p.dtype, device=p.device))
+
+    @torch.no_grad()
+    def full_state_dict(self, fsdp_module):
+        live_state = {}
+        for n, p in fsdp_module.module.named_parameters():
+            live_state[n] = p.detach().clone()
+        for n, p in fsdp_module.module.named_parameters():
+            if n in self.shadow:
+                p.data.copy_(self.shadow[n].to(dtype=p.dtype, device=p.device))
+
+        checkpoint = fsdp_state_dict(fsdp_module)
+        shadow_checkpoint = {}
+        for n in self.shadow:
+            k = n
+            if k not in checkpoint and k.startswith("model._fsdp_wrapped_module."):
+                k = k.replace("model._fsdp_wrapped_module.", "model.", 1)
+            if k in checkpoint:
+                shadow_checkpoint[n] = checkpoint[k]
+        for n, p in fsdp_module.module.named_parameters():
+            if n in live_state:
+                p.data.copy_(live_state[n].to(dtype=p.dtype, device=p.device))
+
+        return shadow_checkpoint

--- a/trainer/diffusion.py
+++ b/trainer/diffusion.py
@@ -173,7 +173,7 @@ class Trainer:
         if self.config.ema_start_step < self.step:
             state_dict = {
                 "generator": generator_state_dict,
-                "generator_ema": self.generator_ema.state_dict(),
+                "generator_ema": self.generator_ema.full_state_dict(self.model.generator),
             }
         else:
             state_dict = {

--- a/trainer/distillation.py
+++ b/trainer/distillation.py
@@ -194,7 +194,7 @@ class Trainer:
 
         if self.config.ema_start_step < self.step:
             state_dict = {
-                "generator_ema": self.generator_ema.state_dict(),
+                "generator_ema": self.generator_ema.full_state_dict(self.model.generator),
             }
         else:
             state_dict = {

--- a/trainer/gan.py
+++ b/trainer/gan.py
@@ -216,7 +216,7 @@ class Trainer:
             state_dict = {
                 "generator": generator_state_dict,
                 "critic": critic_state_dict,
-                "generator_ema": self.generator_ema.state_dict(),
+                "generator_ema": self.generator_ema.full_state_dict(self.model.generator),
             }
         else:
             state_dict = {

--- a/trainer/naive_cd.py
+++ b/trainer/naive_cd.py
@@ -187,7 +187,7 @@ class Trainer:
 
         if self.config.ema_start_step < self.step:
             state_dict = {
-                "generator_ema": self.generator_ema.state_dict(),
+                "generator_ema": self.generator_ema.full_state_dict(self.model.generator),
             }
         else:
             state_dict = {

--- a/utils/distributed.py
+++ b/utils/distributed.py
@@ -96,18 +96,14 @@ class EMA_FSDP:
 
     @torch.no_grad()
     def _init_shadow(self, fsdp_module):
-        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-        with FSDP.summon_full_params(fsdp_module, writeback=False):
-            for n, p in fsdp_module.module.named_parameters():
-                self.shadow[n] = p.detach().clone().float().cpu()
+        for n, p in fsdp_module.module.named_parameters():
+            self.shadow[n] = p.detach().clone().float().cpu()
 
     @torch.no_grad()
     def update(self, fsdp_module):
         d = self.decay
-        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-        with FSDP.summon_full_params(fsdp_module, writeback=False):
-            for n, p in fsdp_module.module.named_parameters():
-                self.shadow[n].mul_(d).add_(p.detach().float().cpu(), alpha=1. - d)
+        for n, p in fsdp_module.module.named_parameters():
+            self.shadow[n].mul_(d).add_(p.detach().float().cpu(), alpha=1. - d)
 
     # Optional helpers ---------------------------------------------------
     def state_dict(self):
@@ -117,10 +113,29 @@ class EMA_FSDP:
         self.shadow = {k: v.clone() for k, v in sd.items()}
 
     def copy_to(self, fsdp_module):
-        # load EMA weights into an (unwrapped) copy of the generator
-        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-        with FSDP.summon_full_params(fsdp_module, writeback=True):
-            for n, p in fsdp_module.module.named_parameters():
-                if n in self.shadow:
-                    p.data.copy_(self.shadow[n].to(dtype=p.dtype, device=p.device))
+        for n, p in fsdp_module.module.named_parameters():
+            if n in self.shadow:
+                p.data.copy_(self.shadow[n].to(dtype=p.dtype, device=p.device))
 
+    @torch.no_grad()
+    def full_state_dict(self, fsdp_module):
+        live_state = {}
+        for n, p in fsdp_module.module.named_parameters():
+            live_state[n] = p.detach().clone()
+        for n, p in fsdp_module.module.named_parameters():
+            if n in self.shadow:
+                p.data.copy_(self.shadow[n].to(dtype=p.dtype, device=p.device))
+
+        checkpoint = fsdp_state_dict(fsdp_module)
+        shadow_checkpoint = {}
+        for n in self.shadow:
+            k = n
+            if k not in checkpoint and k.startswith("model._fsdp_wrapped_module."):
+                k = k.replace("model._fsdp_wrapped_module.", "model.", 1)
+            if k in checkpoint:
+                shadow_checkpoint[n] = checkpoint[k]
+        for n, p in fsdp_module.module.named_parameters():
+            if n in live_state:
+                p.data.copy_(live_state[n].to(dtype=p.dtype, device=p.device))
+
+        return shadow_checkpoint


### PR DESCRIPTION
# Summary

This PR changes the EMA path so that EMA is maintained as local shards during training instead of materializing full parameters on every rank.

The previous implementation used `summon_full_params()` in the EMA hot path, which adds unnecessary communication and keeps a full CPU EMA copy on each rank. With this change, each rank updates only its local EMA shard during training, which reduces both EMA memory usage and per-step overhead.

To preserve the existing checkpoint format, `generator_ema` is still exported as a full state dict at save time. Since EMA is shard-local during training, `full_state_dict()` reuses the FSDP-wrapped module together with `fsdp_state_dict()` to gather the full checkpoint, instead of introducing a separate EMA-specific export path.

# Changes

- keep `EMA_FSDP` shard-local during training
- remove `summon_full_params()` from EMA init/update/copy
- export full `generator_ema` only at save time
- switch trainer save paths to use `self.generator_ema.full_state_dict(self.model.generator)`
- use `to(dtype=..., device=...)` when copying EMA tensors back, for better compatibility with newer PyTorch versions