### PR TITLE
Speed up chunkwise ODE trajectory generation with optional blockwise KV caching

### DIFF
--- a/get_causal_ode_data_chunkwise.py
+++ b/get_causal_ode_data_chunkwise.py
@@ -1,42 +1,108 @@
-from utils.wan_wrapper import WanDiffusionWrapper, WanTextEncoder, WanVAEWrapper
-from utils.scheduler import FlowMatchScheduler
-from utils.distributed import launch_distributed_job
-
-import torch.distributed as dist
-from tqdm import tqdm
 import argparse
-import torch
 import math
 import os
+
+import torch
+import torch.distributed as dist
+from tqdm import tqdm
+
 from utils.dataset import LatentLMDBDataset
+from utils.distributed import launch_distributed_job
+from utils.ode_generation import (
+    CausalODETrajectoryGenerator,
+    merge_cfg_prompt_embeds,
+)
+from utils.scheduler import FlowMatchScheduler
+from utils.wan_wrapper import WanDiffusionWrapper, WanTextEncoder
 
-def init_model(device):
+
+DEFAULT_NEGATIVE_PROMPT = (
+    "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，"
+    "最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，"
+    "画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，"
+    "杂乱的背景，三条腿，背景人很多，倒着走"
+)
+DEFAULT_NUM_FRAME_PER_BLOCK = 3
+DEFAULT_NUM_INFERENCE_STEPS = 48
+DEFAULT_SCHEDULER_SHIFT = 5.0
+DEFAULT_TARGET_NUM_FRAMES = 21
+DEFAULT_TRAJECTORY_INDICES = [0, 12, 24, 36, -2, -1]
+
+
+def normalize_generator_state_dict(state_dict: dict) -> dict:
+    if "generator" in state_dict:
+        state_dict = state_dict["generator"]
+    elif "generator_ema" in state_dict:
+        state_dict = state_dict["generator_ema"]
+
+    fixed = {}
+    for k, v in state_dict.items():
+        if k.startswith("model._fsdp_wrapped_module."):
+            k = k.replace("model._fsdp_wrapped_module.", "", 1)
+        if k.startswith("model."):
+            k = k.replace("model.", "", 1)
+        fixed[k] = v
+    return fixed
+
+
+def init_model(
+    device,
+    num_frame_per_block: int,
+    scheduler_shift: float,
+    num_inference_steps: int,
+    negative_prompt: str,
+):
     model = WanDiffusionWrapper(is_causal=True).to(device).to(torch.float32)
-    model.model.num_frame_per_block = 3 # !!
+    model.model.num_frame_per_block = num_frame_per_block
     encoder = WanTextEncoder().to(device).to(torch.float32)
-    
 
-    scheduler = FlowMatchScheduler(shift=5.0, sigma_min=0.0, extra_one_step=True)
-    scheduler.set_timesteps(num_inference_steps=48, denoising_strength=1.0)
+    scheduler = FlowMatchScheduler(
+        shift=scheduler_shift,
+        sigma_min=0.0,
+        extra_one_step=True,
+    )
+    scheduler.set_timesteps(
+        num_inference_steps=num_inference_steps,
+        denoising_strength=1.0,
+    )
     scheduler.sigmas = scheduler.sigmas.to(device)
 
-    sample_neg_prompt = '色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走'
-
-    unconditional_dict = encoder(
-        text_prompts=[sample_neg_prompt]
-    )
-
+    unconditional_dict = encoder(text_prompts=[negative_prompt])
     return model, encoder, scheduler, unconditional_dict
+
+
+def prepare_clean_latent(
+    sample: dict,
+    target_num_frames: int | None,
+    device,
+) -> torch.Tensor:
+    clean_latent = sample["clean_latent"].to(device).unsqueeze(0)
+    if target_num_frames is None:
+        return clean_latent
+
+    if clean_latent.shape[1] < target_num_frames:
+        raise ValueError(
+            "clean_latent has fewer frames than requested: "
+            f"{clean_latent.shape[1]} < {target_num_frames}"
+        )
+    if clean_latent.shape[1] != target_num_frames:
+        clean_latent = clean_latent[:, :target_num_frames, ...]
+    return clean_latent.contiguous()
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--local_rank", type=int, default=-1)
-    parser.add_argument("--output_folder", type=str)
-    parser.add_argument("--rawdata_path", type=str)
-    parser.add_argument("--generator_ckpt", type=str)
+    parser.add_argument("--output_folder", type=str, required=True)
+    parser.add_argument("--rawdata_path", type=str, required=True)
+    parser.add_argument("--generator_ckpt", type=str, required=True)
     parser.add_argument("--guidance_scale", type=float, default=6.0)
-
+    parser.add_argument(
+        "--generation_mode",
+        type=str,
+        default="full",
+        choices=["full", "blockwise_kv"],
+    )
 
     args = parser.parse_args()
 
@@ -49,88 +115,70 @@ def main():
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True
 
-    model, encoder, scheduler, unconditional_dict = init_model(device=device)
+    model, encoder, scheduler, unconditional_dict = init_model(
+        device=device,
+        num_frame_per_block=DEFAULT_NUM_FRAME_PER_BLOCK,
+        scheduler_shift=DEFAULT_SCHEDULER_SHIFT,
+        num_inference_steps=DEFAULT_NUM_INFERENCE_STEPS,
+        negative_prompt=DEFAULT_NEGATIVE_PROMPT,
+    )
     state_dict = torch.load(args.generator_ckpt, map_location="cpu")
-        
-    gen_sd = state_dict["generator"]
-    fixed = {}
-    for k, v in gen_sd.items():
-        if k.startswith("model._fsdp_wrapped_module."):
-            k = k.replace("model._fsdp_wrapped_module.", "", 1)
-        if k.startswith("model."):
-            k = k.replace("model.", "", 1)
-        fixed[k] = v
-    state_dict = fixed
     model.model.load_state_dict(
-        state_dict, strict=True
+        normalize_generator_state_dict(state_dict),
+        strict=True,
     )
 
-
-
-    dataset = LatentLMDBDataset(args.rawdata_path)
+    dataset = LatentLMDBDataset(
+        args.rawdata_path,
+        max_pair=int(1e8),
+    )
 
     if global_rank == 0:
         os.makedirs(args.output_folder, exist_ok=True)
-        
+
+    trajectory_generator = CausalODETrajectoryGenerator(
+        model=model,
+        scheduler=scheduler,
+        num_frame_per_block=DEFAULT_NUM_FRAME_PER_BLOCK,
+        num_inference_steps=DEFAULT_NUM_INFERENCE_STEPS,
+        guidance_scale=args.guidance_scale,
+    )
+
     total_steps = int(math.ceil(len(dataset) / dist.get_world_size()))
     for index in tqdm(
-        range(total_steps), disable=(dist.get_rank() != 0),
+        range(total_steps), disable=(global_rank != 0),
     ):
-        prompt_index = index * dist.get_world_size() + dist.get_rank()
+        prompt_index = index * dist.get_world_size() + global_rank
         if prompt_index >= len(dataset):
             continue
+
+        output_path = os.path.join(args.output_folder, f"{prompt_index:05d}.pt")
+
         sample = dataset[prompt_index]
         prompt = sample["prompts"]
-       
-        clean_latent = sample["clean_latent"].to(device).unsqueeze(0)
-        
-        
-
-        conditional_dict = encoder(
-            text_prompts=prompt
+        clean_latent = prepare_clean_latent(
+            sample=sample,
+            target_num_frames=DEFAULT_TARGET_NUM_FRAMES,
+            device=device,
         )
 
-        latents = torch.randn(
-            [1, 21, 16, 60, 104], dtype=torch.float32, device=device
+        conditional_dict = encoder(text_prompts=[prompt])
+        paired_conditional_dict = merge_cfg_prompt_embeds(
+            conditional_dict=conditional_dict,
+            unconditional_dict=unconditional_dict,
         )
-        
-        noisy_input = []
-
-        for progress_id, t in enumerate(tqdm(scheduler.timesteps, disable=(dist.get_rank() != 0))):
-            timestep = t * \
-                torch.ones([1, 21], device=device, dtype=torch.float32)
-            noisy_input.append(latents)
-            f_cond, x0_pred_cond = model(
-                latents, conditional_dict, timestep, clean_x = clean_latent
-            )
-
-            f_uncond, x0_pred_uncond = model(
-                latents, unconditional_dict, timestep, clean_x = clean_latent
-            )
-
-            flow_pred = f_uncond + args.guidance_scale * (
-                f_cond - f_uncond
-            )
-            
-            
-            latents = scheduler.step(
-                flow_pred.flatten(0, 1),
-                timestep.flatten(0, 1),
-                latents.flatten(0, 1)
-            ).unflatten(dim=0, sizes=flow_pred.shape[:2])
-
-        noisy_input.append(latents)
-        noisy_input.append(clean_latent)
-        
-        noisy_inputs = torch.stack(noisy_input, dim=1)
-
-        noisy_inputs = noisy_inputs[:, [0, 12, 24, 36, -2, -1]]
-
-        stored_data = noisy_inputs
+        initial_noise = torch.randn_like(clean_latent, dtype=torch.float32)
+        stored_data = trajectory_generator.generate(
+            clean_latent=clean_latent,
+            paired_conditional_dict=paired_conditional_dict,
+            trajectory_indices=DEFAULT_TRAJECTORY_INDICES,
+            generation_mode=args.generation_mode,
+            initial_noise=initial_noise,
+        )
 
         torch.save(
             {prompt: stored_data.cpu().detach()},
-            os.path.join(args.output_folder, f"{prompt_index:05d}.pt")
+            output_path,
         )
 
     dist.barrier()

--- a/utils/ode_generation.py
+++ b/utils/ode_generation.py
@@ -1,0 +1,327 @@
+from typing import Dict, Iterable, Optional
+
+import torch
+
+
+def merge_cfg_prompt_embeds(
+    conditional_dict: dict,
+    unconditional_dict: dict,
+) -> dict:
+    cond = conditional_dict["prompt_embeds"]
+    uncond = unconditional_dict["prompt_embeds"]
+
+    if isinstance(cond, torch.Tensor):
+        prompt_embeds = torch.cat([cond, uncond], dim=0)
+    else:
+        prompt_embeds = list(cond) + list(uncond)
+
+    return {"prompt_embeds": prompt_embeds}
+
+
+def normalize_trajectory_indices(
+    trajectory_indices: Iterable[int],
+    num_inference_steps: int,
+) -> list[int]:
+    total = num_inference_steps + 2
+    normalized = []
+    for idx in trajectory_indices:
+        norm_idx = idx if idx >= 0 else total + idx
+        if norm_idx < 0 or norm_idx >= total:
+            raise IndexError(
+                f"trajectory index {idx} is out of range for a trajectory of length {total}"
+            )
+        normalized.append(norm_idx)
+    return normalized
+
+
+class CausalODETrajectoryGenerator:
+    def __init__(
+        self,
+        model,
+        scheduler,
+        num_frame_per_block: int,
+        num_inference_steps: int,
+        guidance_scale: float,
+    ) -> None:
+        self.model = model
+        self.scheduler = scheduler
+        self.num_frame_per_block = num_frame_per_block
+        self.num_inference_steps = num_inference_steps
+        self.guidance_scale = guidance_scale
+        self.frame_seq_length = 1560
+        self.num_transformer_blocks = len(self.model.model.blocks)
+        self.local_attn_size = self.model.model.local_attn_size
+
+    def _make_kv_cache(self, batch_size: int, device: torch.device) -> list[dict]:
+        if self.local_attn_size != -1:
+            kv_cache_size = self.local_attn_size * self.frame_seq_length
+        else:
+            kv_cache_size = 32760
+
+        kv_cache = []
+        for _ in range(self.num_transformer_blocks):
+            kv_cache.append(
+                {
+                    "k": torch.zeros(
+                        [batch_size, kv_cache_size, 12, 128],
+                        dtype=torch.float32,
+                        device=device,
+                    ),
+                    "v": torch.zeros(
+                        [batch_size, kv_cache_size, 12, 128],
+                        dtype=torch.float32,
+                        device=device,
+                    ),
+                    "global_end_index": torch.tensor([0], dtype=torch.long, device=device),
+                    "local_end_index": torch.tensor([0], dtype=torch.long, device=device),
+                }
+            )
+        return kv_cache
+
+    def _make_crossattn_cache(self, batch_size: int, device: torch.device) -> list[dict]:
+        crossattn_cache = []
+        for _ in range(self.num_transformer_blocks):
+            crossattn_cache.append(
+                {
+                    "k": torch.zeros(
+                        [batch_size, 512, 12, 128],
+                        dtype=torch.float32,
+                        device=device,
+                    ),
+                    "v": torch.zeros(
+                        [batch_size, 512, 12, 128],
+                        dtype=torch.float32,
+                        device=device,
+                    ),
+                    "is_init": False,
+                }
+            )
+        return crossattn_cache
+
+    def _batched_cfg_step(
+        self,
+        latents: torch.Tensor,
+        paired_conditional_dict: dict,
+        timestep: torch.Tensor,
+        clean_x: Optional[torch.Tensor] = None,
+        kv_cache: Optional[list[dict]] = None,
+        crossattn_cache: Optional[list[dict]] = None,
+        current_start: Optional[int] = None,
+    ) -> torch.Tensor:
+        latents_pair = latents.repeat(2, 1, 1, 1, 1)
+        timestep_pair = timestep.repeat(2, 1)
+
+        clean_pair = None
+        if clean_x is not None:
+            clean_pair = clean_x.repeat(2, 1, 1, 1, 1)
+
+        flow_pair, _ = self.model(
+            latents_pair,
+            paired_conditional_dict,
+            timestep_pair,
+            kv_cache=kv_cache,
+            crossattn_cache=crossattn_cache,
+            current_start=current_start,
+            clean_x=clean_pair,
+        )
+
+        flow_cond = flow_pair[:1].float()
+        flow_uncond = flow_pair[1:2].float()
+        return flow_uncond + self.guidance_scale * (flow_cond - flow_uncond)
+
+    def _update_clean_cache(
+        self,
+        clean_x: torch.Tensor,
+        paired_conditional_dict: dict,
+        kv_cache: list[dict],
+        crossattn_cache: list[dict],
+        current_start: int,
+    ) -> None:
+        timestep = torch.full(
+            [1, clean_x.shape[1]],
+            0.0,
+            device=clean_x.device,
+            dtype=torch.float32,
+        )
+        with torch.no_grad():
+            self._batched_cfg_step(
+                latents=clean_x,
+                paired_conditional_dict=paired_conditional_dict,
+                timestep=timestep,
+                kv_cache=kv_cache,
+                crossattn_cache=crossattn_cache,
+                current_start=current_start,
+            )
+
+    def _generate_full(
+        self,
+        clean_latent: torch.Tensor,
+        paired_conditional_dict: dict,
+        normalized_indices: list[int],
+        initial_noise: torch.Tensor,
+    ) -> torch.Tensor:
+        latents = initial_noise.clone()
+        selected_steps = {idx for idx in normalized_indices if idx < self.num_inference_steps}
+        step_snapshots: Dict[int, torch.Tensor] = {}
+
+        frame_count = latents.shape[1]
+        for step_idx, t in enumerate(self.scheduler.timesteps):
+            if step_idx in selected_steps:
+                step_snapshots[step_idx] = latents.clone()
+
+            timestep = t * torch.ones(
+                [1, frame_count],
+                device=latents.device,
+                dtype=torch.float32,
+            )
+            flow_pred = self._batched_cfg_step(
+                latents=latents,
+                paired_conditional_dict=paired_conditional_dict,
+                timestep=timestep,
+                clean_x=clean_latent,
+            )
+            latents = self.scheduler.step(
+                flow_pred.flatten(0, 1),
+                timestep.flatten(0, 1),
+                latents.flatten(0, 1),
+            ).unflatten(dim=0, sizes=flow_pred.shape[:2])
+
+        return self._assemble_selected_trajectory(
+            clean_latent=clean_latent,
+            final_latent=latents,
+            normalized_indices=normalized_indices,
+            step_snapshots=step_snapshots,
+        )
+
+    def _generate_blockwise_kv(
+        self,
+        clean_latent: torch.Tensor,
+        paired_conditional_dict: dict,
+        normalized_indices: list[int],
+        initial_noise: torch.Tensor,
+    ) -> torch.Tensor:
+        num_frames = clean_latent.shape[1]
+        if num_frames % self.num_frame_per_block != 0:
+            raise ValueError(
+                f"num_frames={num_frames} must be divisible by num_frame_per_block={self.num_frame_per_block}"
+            )
+
+        kv_cache = self._make_kv_cache(batch_size=2, device=clean_latent.device)
+        crossattn_cache = self._make_crossattn_cache(batch_size=2, device=clean_latent.device)
+
+        selected_steps = {idx for idx in normalized_indices if idx < self.num_inference_steps}
+        step_snapshots = {
+            idx: torch.empty_like(clean_latent)
+            for idx in selected_steps
+        }
+        final_latent = torch.empty_like(clean_latent)
+
+        num_blocks = num_frames // self.num_frame_per_block
+        for block_idx in range(num_blocks):
+            start = block_idx * self.num_frame_per_block
+            end = start + self.num_frame_per_block
+            current_start = start * self.frame_seq_length
+
+            block_clean = clean_latent[:, start:end].contiguous()
+            block_latents = initial_noise[:, start:end].clone()
+
+            for step_idx, t in enumerate(self.scheduler.timesteps):
+                if step_idx in selected_steps:
+                    step_snapshots[step_idx][:, start:end] = block_latents
+
+                timestep = t * torch.ones(
+                    [1, block_latents.shape[1]],
+                    device=block_latents.device,
+                    dtype=torch.float32,
+                )
+                flow_pred = self._batched_cfg_step(
+                    latents=block_latents,
+                    paired_conditional_dict=paired_conditional_dict,
+                    timestep=timestep,
+                    kv_cache=kv_cache,
+                    crossattn_cache=crossattn_cache,
+                    current_start=current_start,
+                )
+                block_latents = self.scheduler.step(
+                    flow_pred.flatten(0, 1),
+                    timestep.flatten(0, 1),
+                    block_latents.flatten(0, 1),
+                ).unflatten(dim=0, sizes=flow_pred.shape[:2])
+
+            final_latent[:, start:end] = block_latents
+            self._update_clean_cache(
+                clean_x=block_clean,
+                paired_conditional_dict=paired_conditional_dict,
+                kv_cache=kv_cache,
+                crossattn_cache=crossattn_cache,
+                current_start=current_start,
+            )
+
+        return self._assemble_selected_trajectory(
+            clean_latent=clean_latent,
+            final_latent=final_latent,
+            normalized_indices=normalized_indices,
+            step_snapshots=step_snapshots,
+        )
+
+    def _assemble_selected_trajectory(
+        self,
+        clean_latent: torch.Tensor,
+        final_latent: torch.Tensor,
+        normalized_indices: list[int],
+        step_snapshots: Dict[int, torch.Tensor],
+    ) -> torch.Tensor:
+        selected = []
+        final_index = self.num_inference_steps
+        clean_index = self.num_inference_steps + 1
+
+        for idx in normalized_indices:
+            if idx < self.num_inference_steps:
+                selected.append(step_snapshots[idx])
+            elif idx == final_index:
+                selected.append(final_latent)
+            elif idx == clean_index:
+                selected.append(clean_latent)
+            else:
+                raise RuntimeError(f"Unexpected normalized trajectory index: {idx}")
+
+        return torch.stack(selected, dim=1)
+
+    def generate(
+        self,
+        clean_latent: torch.Tensor,
+        paired_conditional_dict: dict,
+        trajectory_indices: Iterable[int],
+        generation_mode: str = "blockwise_kv",
+        initial_noise: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if generation_mode not in {"full", "blockwise_kv"}:
+            raise ValueError(f"Unsupported generation_mode: {generation_mode}")
+
+        normalized_indices = normalize_trajectory_indices(
+            trajectory_indices=trajectory_indices,
+            num_inference_steps=self.num_inference_steps,
+        )
+
+        if initial_noise is None:
+            initial_noise = torch.randn_like(clean_latent, dtype=torch.float32)
+        else:
+            initial_noise = initial_noise.to(
+                device=clean_latent.device,
+                dtype=torch.float32,
+            )
+
+        with torch.no_grad():
+            if generation_mode == "full":
+                return self._generate_full(
+                    clean_latent=clean_latent,
+                    paired_conditional_dict=paired_conditional_dict,
+                    normalized_indices=normalized_indices,
+                    initial_noise=initial_noise,
+                )
+            return self._generate_blockwise_kv(
+                clean_latent=clean_latent,
+                paired_conditional_dict=paired_conditional_dict,
+                normalized_indices=normalized_indices,
+                initial_noise=initial_noise,
+            )


### PR DESCRIPTION
## Summary
This PR speeds up chunkwise ODE trajectory generation by adding an optional blockwise KV-cached generation path to the preprocessing script.

The previous implementation denoised the full latent sequence at every ODE step, which recomputes context that is already fixed given the AR teacher's causal structure. With this change, ODE trajectories can be generated block by block while reusing cached causal states from earlier blocks, which substantially reduces preprocessing time.

To preserve the existing behavior, the original full-sequence path remains the default. The new path is exposed only as an optional generation mode, so existing preprocessing jobs continue to run unchanged unless explicitly switched to the faster blockwise path.

## Changes
- extract ODE trajectory generation into `utils/ode_generation.py`
- add `--generation_mode {full, blockwise_kv}` to `get_causal_ode_data_chunkwise.py`
- generate chunkwise ODE trajectories block by block while reusing causal KV cache
- batch conditional and unconditional CFG passes together in the new generator path

## Benchmark
Single-sample fp32 benchmark on NVIDIA H20:

- `full`: `1009.8s`
- `blockwise_kv`: `296.1s`
- speedup: `3.41x`

Numerical difference relative to the original fp32 full-sequence pipeline:

- `max_abs_diff`: `2.4475`
- `mean_abs_diff`: `0.00626`
